### PR TITLE
fix: grap tap event

### DIFF
--- a/granite-file-saver.html
+++ b/granite-file-saver.html
@@ -41,7 +41,7 @@ Typical usage:
         }
       </style>
 
-      <slot on-tap="_onTap"></slot>
+      <slot></slot>
       <a id="hiddenSaver" href$="[[_file]]" download="{{_filename}}" hidden></a>
     </template>
 
@@ -103,11 +103,11 @@ Typical usage:
           }
 
         },
-
-        observers: [
-        ],
+        
         listeners: {
+          'tap': '_onTap',
         },
+        
         _onTap: function(evt) {
           evt.stopPropagation();
 


### PR DESCRIPTION
`on-tap` on `<slot>` not work anymore in new polymers (1.10 && 2.x)

@LostInBrittany I use this component in production mode, could you please merge and release new tag as soon as possible, thank you in advance